### PR TITLE
Correcciones en el formulario del perfil de usuario

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -376,6 +376,3 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
   web-console (~> 2.0)
   will_paginate (= 3.0.7)
-
-BUNDLED WITH
-   1.11.2

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -6,21 +6,21 @@
       } do |f| %>
       <fieldset>
         <legend>Datos generales</legend>
-        <%= f.input :email %>
-        <%= error_span(@user[:email]) %>
         <%= f.input :user_name %>
         <%= error_span(@user[:user_name]) %>
-        <%= f.input :image_profile, as: :file %>
-        <%= error_span(@user[:image_profile]) %>
-      </fieldset>
-
-      <fieldset>
-        <legend>Intereses</legend>
         <%= f.simple_fields_for :person do |person_form| %>
             <%= person_form.input :name %>
             <%= error_span(@user[:name]) %>
             <%= person_form.input :last_name %>
             <%= error_span(@user[:last_name]) %>
+        <% end %>
+        <%= f.input :image_profile, as: :file %>
+        <%= error_span(@user[:image_profile]) %>
+      </fieldset>
+      <br>
+      <fieldset>
+        <legend>Intereses</legend>
+        <%= f.simple_fields_for :person do |person_form| %>
             <%= person_form.input :university %>
             <%= error_span(@user[:university]) %>
             <%= person_form.input :first_choice %>
@@ -32,10 +32,11 @@
         <% end %>
       </fieldset>
 
-
-      <%= f.button :submit, :class => 'btn-primary' %>
-      <%= link_to t('.cancel', :default => t('helpers.links.cancel')),
-                  :back, :class => 'btn btn-default' %>
+      <div class="pull-right">
+        <%= link_to t('.cancel', :default => t('helpers.links.cancel')),
+                    :back, :class => 'btn btn-default' %>
+        <%= f.button :submit, :class => 'btn-primary' %>    
+      </div>
   <% end %>
 
 </div>


### PR DESCRIPTION
Se modifica la vista en base al mockup actualizado que mostró carlos.
La funcionalidad se mantiene igual pero el layout es ligeramente distinto y se quita el campo de "correo", ya que de todas formas no se puede ni debe poder modificar. Así también ya debe pasar con 100% de calidad el CP-18, ya que ese era su único error.